### PR TITLE
Remove warning for Elixir 1.5.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule FlakyConnection.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Remove this warning:
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:10